### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.1] - 2025-08-27
+
+### 🚀 Features
+
+- Add `arc` and `rc` support
+
+### 🧪 Testing
+
+- Add sanity-check tests
+
+### ⚙️ Miscellaneous Tasks
+
+- Use token for release pr's
+- Update funding information
+- Add cargo-expand to dev shell

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "match-wrap"
 description = "Wrap incompatible match arms with a trait object container"
 authors = ["Callum Leslie <git@cleslie.uk>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 documentation = "https://docs.rs/match-wrap"
 homepage = "https://github.com/callumio/match-wrap"


### PR DESCRIPTION



## 🤖 New release

* `match-wrap`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2025-08-27

### 🚀 Features

- Add `arc` and `rc` support

### 🧪 Testing

- Add sanity-check tests

### ⚙️ Miscellaneous Tasks

- Use token for release pr's
- Update funding information
- Add cargo-expand to dev shell
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).