### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.2] - 2025-09-01
+
+### 🐛 Bug Fixes
+
+- Proper error message for bad containers
+
+### 💼 Other
+
+- *(deps)* Bump actions/checkout from 4 to 5
+
+### 📚 Documentation
+
+- Add README to rust docs
+
+### ⚙️ Miscellaneous Tasks
+
+- Ignore config files in cargo release
 ## [0.1.1] - 2025-08-27
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "match-wrap"
 description = "Wrap incompatible match arms with a trait object container"
 authors = ["Callum Leslie <git@cleslie.uk>"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 documentation = "https://docs.rs/match-wrap"
 homepage = "https://github.com/callumio/match-wrap"


### PR DESCRIPTION



## 🤖 New release

* `match-wrap`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2] - 2025-09-01

### 🐛 Bug Fixes

- Proper error message for bad containers

### 💼 Other

- *(deps)* Bump actions/checkout from 4 to 5

### 📚 Documentation

- Add README to rust docs

### ⚙️ Miscellaneous Tasks

- Ignore config files in cargo release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).